### PR TITLE
Make auth mehods to private

### DIFF
--- a/lib/embulk/input/sfdc.rb
+++ b/lib/embulk/input/sfdc.rb
@@ -53,7 +53,7 @@ module Embulk
           security_token: config.param("security_token", :string),
         }
 
-        client = Sfdc::Api.new(login_url).setup(config)
+        client = Sfdc::Api.new.setup(login_url, config)
 
         metadata = client.get_metadata(target)
 
@@ -73,7 +73,7 @@ module Embulk
       end
 
       def init
-        @api = Sfdc::Api.new(task["login_url"]).setup(task["config"])
+        @api = Sfdc::Api.new.setup(task["login_url"], task["config"])
         @schema = task["schema"]
         @soql = task["soql"]
       end

--- a/lib/embulk/input/sfdc.rb
+++ b/lib/embulk/input/sfdc.rb
@@ -53,7 +53,7 @@ module Embulk
           security_token: config.param("security_token", :string),
         }
 
-        client = Sfdc::Api.setup(login_url, config)
+        client = Sfdc::Api.new(login_url).setup(config)
 
         metadata = client.get_metadata(target)
 
@@ -73,7 +73,7 @@ module Embulk
       end
 
       def init
-        @api = Sfdc::Api.setup(task["login_url"], task["config"])
+        @api = Sfdc::Api.new(task["login_url"]).setup(task["config"])
         @schema = task["schema"]
         @soql = task["soql"]
       end

--- a/lib/embulk/input/sfdc/api.rb
+++ b/lib/embulk/input/sfdc/api.rb
@@ -9,20 +9,20 @@ module Embulk
 
         attr_reader :client
 
-        def setup(config)
-          token = authentication(config)
+        def setup(login_url, config)
+          token = authentication(login_url, config)
           set_latest_version(token)
           self
         end
 
-        def initialize(login_url)
-          @login_url = login_url
+        def initialize
+          @login_url = ""
           @version_path = ""
           @client = HTTPClient.new
           @client.default_header = {Accept: 'application/json; charset=UTF-8'}
         end
 
-        def authentication(_config)
+        def authentication(login_url, _config)
           # NOTE: At SfdcInputPlugin#init, we use Symbol as each key
           #       for task (Hash), but at SfdcInputPlugin#run, task
           #       has them as String...:(
@@ -38,7 +38,7 @@ module Embulk
             password: config[:password] + config[:security_token]
           }
 
-          oauth_response = @client.post(@login_url + "/services/oauth2/token", params)
+          oauth_response = @client.post(login_url + "/services/oauth2/token", params)
           oauth = JSON.parse(oauth_response.body)
 
           client.base_url = oauth["instance_url"]

--- a/lib/embulk/input/sfdc/api.rb
+++ b/lib/embulk/input/sfdc/api.rb
@@ -22,6 +22,23 @@ module Embulk
           @client.default_header = {Accept: 'application/json; charset=UTF-8'}
         end
 
+        def get(path, parameters={})
+          # TODO: Use this method by #get_metadata and #search
+          # TODO: error handling
+          JSON.parse(client.get(path, parameters).body)
+        end
+
+        def get_metadata(sobject_name)
+          sobject_metadata = client.get(@version_path.join("sobjects/#{sobject_name}/describe").to_s)
+          JSON.parse(sobject_metadata.body)
+        end
+
+        def search(soql)
+          JSON.parse(client.get(@version_path.join("query").to_s, {q: soql}).body)
+        end
+
+        private
+
         def authentication(login_url, _config)
           # NOTE: At SfdcInputPlugin#init, we use Symbol as each key
           #       for task (Hash), but at SfdcInputPlugin#run, task
@@ -54,21 +71,6 @@ module Embulk
           client.default_header = client.default_header.merge(Authorization: "Bearer #{access_token}")
 
           self
-        end
-
-        def get(path, parameters={})
-          # TODO: Use this method by #get_metadata and #search
-          # TODO: error handling
-          JSON.parse(client.get(path, parameters).body)
-        end
-
-        def get_metadata(sobject_name)
-          sobject_metadata = client.get(@version_path.join("sobjects/#{sobject_name}/describe").to_s)
-          JSON.parse(sobject_metadata.body)
-        end
-
-        def search(soql)
-          JSON.parse(client.get(@version_path.join("query").to_s, {q: soql}).body)
         end
       end
     end

--- a/lib/embulk/input/sfdc/api.rb
+++ b/lib/embulk/input/sfdc/api.rb
@@ -16,7 +16,6 @@ module Embulk
         end
 
         def initialize
-          @login_url = ""
           @version_path = ""
           @client = HTTPClient.new
           @client.default_header = {Accept: 'application/json; charset=UTF-8'}

--- a/lib/embulk/input/sfdc/api.rb
+++ b/lib/embulk/input/sfdc/api.rb
@@ -9,12 +9,10 @@ module Embulk
 
         attr_reader :client
 
-        def self.setup(login_url, config)
-          api = new(login_url)
-
-          token = api.authentication(config)
-          api.set_latest_version(token)
-          api
+        def setup(config)
+          token = authentication(config)
+          set_latest_version(token)
+          self
         end
 
         def initialize(login_url)

--- a/lib/embulk/input/sfdc/api.rb
+++ b/lib/embulk/input/sfdc/api.rb
@@ -54,7 +54,7 @@ module Embulk
             password: config[:password] + config[:security_token]
           }
 
-          oauth_response = @client.post(Pathname.new(login_url).join("services/oauth2/token").to_s, params)
+          oauth_response = @client.post(URI.join(login_url, "services/oauth2/token").to_s, params)
           oauth = JSON.parse(oauth_response.body)
 
           client.base_url = oauth["instance_url"]

--- a/lib/embulk/input/sfdc/api.rb
+++ b/lib/embulk/input/sfdc/api.rb
@@ -54,7 +54,7 @@ module Embulk
             password: config[:password] + config[:security_token]
           }
 
-          oauth_response = @client.post(login_url + "/services/oauth2/token", params)
+          oauth_response = @client.post(Pathname.new(login_url).join("services/oauth2/token").to_s, params)
           oauth = JSON.parse(oauth_response.body)
 
           client.base_url = oauth["instance_url"]

--- a/test/embulk/input/sfdc/test-api.rb
+++ b/test/embulk/input/sfdc/test-api.rb
@@ -29,9 +29,8 @@ module Embulk
           end
           mock(@api).set_latest_version("access_token") { @api }
 
-          access_token = @api.setup(login_url, config)
+          @api.setup(login_url, config)
 
-          assert_equal("access_token", access_token)
           assert_equal(instance_url, @api.client.base_url)
         end
 

--- a/test/embulk/input/sfdc/test-api.rb
+++ b/test/embulk/input/sfdc/test-api.rb
@@ -29,7 +29,7 @@ module Embulk
             mock(res).body { authentication_response }
           end
 
-          access_token = @api.authentication(login_url, config)
+          access_token = @api.__send__(:authentication, login_url, config)
 
           assert_equal("access_token", access_token)
           assert_equal(instance_url, @api.client.base_url)
@@ -51,7 +51,7 @@ module Embulk
 
           access_token = @api.authentication(login_url, config)
 
-          @api.set_latest_version(access_token)
+          @api.__send__(:set_latest_version, access_token)
           assert_equal(instance_url, @api.client.base_url)
           assert_equal(version_path, @api.instance_variable_get(:@version_path))
         end

--- a/test/embulk/input/sfdc/test-api.rb
+++ b/test/embulk/input/sfdc/test-api.rb
@@ -5,7 +5,7 @@ module Embulk
     module Sfdc
       class ApiTest < Test::Unit::TestCase
         def setup
-          @api = Sfdc::Api.new(login_url)
+          @api = Sfdc::Api.new
         end
 
         def test_initialize
@@ -15,11 +15,11 @@ module Embulk
 
         def test_setup
           any_instance_of(Sfdc::Api) do |klass|
-            mock(klass).authentication(config) { "access_token" }
+            mock(klass).authentication(login_url, config) { "access_token" }
             mock(klass).set_latest_version("access_token") { klass }
           end
 
-          assert_true(Sfdc::Api.new(login_url).setup(config).instance_of?(Sfdc::Api))
+          assert_true(Sfdc::Api.new.setup(login_url, config).instance_of?(Sfdc::Api))
         end
 
         def test_authentication
@@ -29,14 +29,14 @@ module Embulk
             mock(res).body { authentication_response }
           end
 
-          access_token = @api.authentication(config)
+          access_token = @api.authentication(login_url, config)
 
           assert_equal("access_token", access_token)
           assert_equal(instance_url, @api.client.base_url)
         end
 
         def test_set_latest_version
-          stub(@api).authentication(config) do
+          stub(@api).authentication(login_url, config) do
             @api.client.base_url = instance_url
             "access_token"
           end
@@ -49,7 +49,7 @@ module Embulk
             end
           end
 
-          access_token = @api.authentication(config)
+          access_token = @api.authentication(login_url, config)
 
           @api.set_latest_version(access_token)
           assert_equal(instance_url, @api.client.base_url)
@@ -59,7 +59,7 @@ module Embulk
         def test_get_metadata
           setup_api_stub
 
-          @api.setup(config)
+          @api.setup(login_url, config)
 
           metadata = {"metadata" => "is here"}
           mock(@api.client).get(version_path.join("sobjects/custom__c/describe").to_s) do |res|
@@ -74,7 +74,7 @@ module Embulk
         def test_search
           setup_api_stub
 
-          @api.setup(config)
+          @api.setup(login_url, config)
 
           hit_object = {"Name" => "object1"}
           objects = [hit_object, {"Name" => "object2"}]
@@ -159,7 +159,7 @@ module Embulk
         end
 
         def setup_api_stub
-          stub(@api).setup(config) do
+          stub(@api).setup(login_url, config) do
             @api.client.base_url = instance_url
             @api.instance_variable_set(:@version_path, version_path)
             @api.client.default_header = {Accept: 'application/json; charset=UTF-8', Authorization: "Bearer access_token"}

--- a/test/embulk/input/sfdc/test-api.rb
+++ b/test/embulk/input/sfdc/test-api.rb
@@ -52,7 +52,6 @@ module Embulk
 
             @api.setup(login_url, config)
 
-            assert_equal(instance_url, @api.client.base_url)
             assert_equal(version_path, @api.instance_variable_get(:@version_path))
           end
         end

--- a/test/embulk/input/sfdc/test-api.rb
+++ b/test/embulk/input/sfdc/test-api.rb
@@ -13,6 +13,7 @@ module Embulk
           assert_equal({Accept: 'application/json; charset=UTF-8'}, @api.client.default_header)
         end
 
+        class SetupTest < self
         def test_setup
           any_instance_of(Sfdc::Api) do |klass|
             mock(klass).authentication(login_url, config) { "access_token" }
@@ -54,6 +55,7 @@ module Embulk
           @api.__send__(:set_latest_version, access_token)
           assert_equal(instance_url, @api.client.base_url)
           assert_equal(version_path, @api.instance_variable_get(:@version_path))
+        end
         end
 
         def test_get_metadata

--- a/test/embulk/input/sfdc/test-api.rb
+++ b/test/embulk/input/sfdc/test-api.rb
@@ -14,7 +14,7 @@ module Embulk
         end
 
         class SetupTest < self
-          def test_setup
+          def test_returning_value
             any_instance_of(Sfdc::Api) do |klass|
               mock(klass).authentication(login_url, config) { "access_token" }
               mock(klass).set_latest_version("access_token") { klass }
@@ -25,7 +25,7 @@ module Embulk
             assert_true(Sfdc::Api.new.setup(login_url, config).instance_of?(Sfdc::Api))
           end
 
-          def test_authentication
+          def test_instance_url
             mock(@api.client).post("#{login_url}/services/oauth2/token", params) do |res|
               mock(res).body { authentication_response }
             end
@@ -36,7 +36,7 @@ module Embulk
             assert_equal(instance_url, @api.client.base_url)
           end
 
-          def test_set_latest_version
+          def test_version_path
             stub(@api).authentication(login_url, config) do
               @api.client.base_url = instance_url
               "access_token"

--- a/test/embulk/input/sfdc/test-api.rb
+++ b/test/embulk/input/sfdc/test-api.rb
@@ -14,45 +14,47 @@ module Embulk
         end
 
         class SetupTest < self
-        def test_setup
-          any_instance_of(Sfdc::Api) do |klass|
-            mock(klass).authentication(login_url, config) { "access_token" }
-            mock(klass).set_latest_version("access_token") { klass }
-          end
-
-          assert_true(Sfdc::Api.new.setup(login_url, config).instance_of?(Sfdc::Api))
-        end
-
-        def test_authentication
-          mock(@api.client).post("#{login_url}/services/oauth2/token", params) do |res|
-            mock(res).body { authentication_response }
-          end
-          mock(@api).set_latest_version("access_token") { @api }
-
-          @api.setup(login_url, config)
-
-          assert_equal(instance_url, @api.client.base_url)
-        end
-
-        def test_set_latest_version
-          stub(@api).authentication(login_url, config) do
-            @api.client.base_url = instance_url
-            "access_token"
-          end
-
-          mock(@api.client).get("/services/data") do |res|
-            mock(res).body do
-              [
-                {"label"=>"first", "url"=>"/services/data/v1.0", "version"=>"1.0"},
-                {"label"=>"second", "url"=>version_path, "version"=>"2.0"}].to_json
+          def test_setup
+            any_instance_of(Sfdc::Api) do |klass|
+              mock(klass).authentication(login_url, config) { "access_token" }
+              mock(klass).set_latest_version("access_token") { klass }
             end
+
+            @api.setup(login_url, config)
+
+            assert_true(Sfdc::Api.new.setup(login_url, config).instance_of?(Sfdc::Api))
           end
 
-          @api.setup(login_url, config)
+          def test_authentication
+            mock(@api.client).post("#{login_url}/services/oauth2/token", params) do |res|
+              mock(res).body { authentication_response }
+            end
+            mock(@api).set_latest_version("access_token") { @api }
 
-          assert_equal(instance_url, @api.client.base_url)
-          assert_equal(version_path, @api.instance_variable_get(:@version_path))
-        end
+            @api.setup(login_url, config)
+
+            assert_equal(instance_url, @api.client.base_url)
+          end
+
+          def test_set_latest_version
+            stub(@api).authentication(login_url, config) do
+              @api.client.base_url = instance_url
+              "access_token"
+            end
+
+            mock(@api.client).get("/services/data") do |res|
+              mock(res).body do
+                [
+                  {"label"=>"first", "url"=>"/services/data/v1.0", "version"=>"1.0"},
+                  {"label"=>"second", "url"=>version_path, "version"=>"2.0"}].to_json
+              end
+            end
+
+            @api.setup(login_url, config)
+
+            assert_equal(instance_url, @api.client.base_url)
+            assert_equal(version_path, @api.instance_variable_get(:@version_path))
+          end
         end
 
         def test_get_metadata

--- a/test/embulk/input/sfdc/test-api.rb
+++ b/test/embulk/input/sfdc/test-api.rb
@@ -24,13 +24,12 @@ module Embulk
         end
 
         def test_authentication
-          stub(@api).set_latest_version("access_token") { @api }
-
           mock(@api.client).post("#{login_url}/services/oauth2/token", params) do |res|
             mock(res).body { authentication_response }
           end
+          mock(@api).set_latest_version("access_token") { @api }
 
-          access_token = @api.__send__(:authentication, login_url, config)
+          access_token = @api.setup(login_url, config)
 
           assert_equal("access_token", access_token)
           assert_equal(instance_url, @api.client.base_url)
@@ -50,9 +49,8 @@ module Embulk
             end
           end
 
-          access_token = @api.authentication(login_url, config)
+          @api.setup(login_url, config)
 
-          @api.__send__(:set_latest_version, access_token)
           assert_equal(instance_url, @api.client.base_url)
           assert_equal(version_path, @api.instance_variable_get(:@version_path))
         end

--- a/test/embulk/input/sfdc/test-api.rb
+++ b/test/embulk/input/sfdc/test-api.rb
@@ -15,14 +15,10 @@ module Embulk
 
         class SetupTest < self
           def test_returning_value
-            any_instance_of(Sfdc::Api) do |klass|
-              mock(klass).authentication(login_url, config) { "access_token" }
-              mock(klass).set_latest_version("access_token") { klass }
-            end
+            mock(@api).authentication(login_url, config) { "access_token" }
+            mock(@api).set_latest_version("access_token") { @api }
 
-            @api.setup(login_url, config)
-
-            assert_true(Sfdc::Api.new.setup(login_url, config).instance_of?(Sfdc::Api))
+            assert_true(@api.setup(login_url, config).instance_of?(Sfdc::Api))
           end
 
           def test_instance_url

--- a/test/embulk/input/sfdc/test-api.rb
+++ b/test/embulk/input/sfdc/test-api.rb
@@ -19,7 +19,7 @@ module Embulk
             mock(klass).set_latest_version("access_token") { klass }
           end
 
-          assert_true(Sfdc::Api.setup(login_url, config).instance_of?(Sfdc::Api))
+          assert_true(Sfdc::Api.new(login_url).setup(config).instance_of?(Sfdc::Api))
         end
 
         def test_authentication
@@ -59,7 +59,7 @@ module Embulk
         def test_get_metadata
           setup_api_stub
 
-          Sfdc::Api.setup(login_url, config)
+          @api.setup(config)
 
           metadata = {"metadata" => "is here"}
           mock(@api.client).get(version_path.join("sobjects/custom__c/describe").to_s) do |res|
@@ -74,7 +74,7 @@ module Embulk
         def test_search
           setup_api_stub
 
-          Sfdc::Api.setup(login_url, config)
+          @api.setup(config)
 
           hit_object = {"Name" => "object1"}
           objects = [hit_object, {"Name" => "object2"}]
@@ -159,7 +159,7 @@ module Embulk
         end
 
         def setup_api_stub
-          stub(Sfdc::Api).setup(login_url, config) do
+          stub(@api).setup(config) do
             @api.client.base_url = instance_url
             @api.instance_variable_set(:@version_path, version_path)
             @api.client.default_header = {Accept: 'application/json; charset=UTF-8', Authorization: "Bearer access_token"}

--- a/test/embulk/input/test_sfdc.rb
+++ b/test/embulk/input/test_sfdc.rb
@@ -5,15 +5,16 @@ module Embulk
   module Input
     class SfdcInputPluginTest < Test::Unit::TestCase
       def test_run
-        @api = Sfdc::Api.new(login_url)
-        mock(Sfdc::Api).setup(login_url, config) do
-          @api.client.base_url = instance_url
-          @api.instance_variable_set(:@version_path, version_path)
-          @api.client.default_header = {Accept: 'application/json; charset=UTF-8', Authorization: "Bearer access_token"}
-          @api
+        any_instance_of(Sfdc::Api) do |klass|
+        mock(klass).setup(config) do
+          api = Sfdc::Api.new(login_url)
+          api.client.base_url = instance_url
+          api.instance_variable_set(:@version_path, version_path)
+          api.client.default_header = {Accept: 'application/json; charset=UTF-8', Authorization: "Bearer access_token"}
+          api
         end
 
-        mock(@api).search(soql) do
+        mock(klass).search(soql) do
           {
             "totalSize" => 5,
             "done" => false,
@@ -22,12 +23,13 @@ module Embulk
           }
         end
 
-        mock(@api).get(next_records_url) do
+        mock(klass).get(next_records_url) do
           {
             "totalSize" => 5,
             "done" => true,
             "records" => records_with_attributes[4..5],
           }
+        end
         end
 
         page_builder = Object.new # add mock later

--- a/test/embulk/input/test_sfdc.rb
+++ b/test/embulk/input/test_sfdc.rb
@@ -6,8 +6,8 @@ module Embulk
     class SfdcInputPluginTest < Test::Unit::TestCase
       def test_run
         any_instance_of(Sfdc::Api) do |klass|
-          mock(klass).setup(config) do
-            api = Sfdc::Api.new(login_url)
+          mock(klass).setup(login_url, config) do
+            api = Sfdc::Api.new
             api.client.base_url = instance_url
             api.instance_variable_set(:@version_path, version_path)
             api.client.default_header = {Accept: 'application/json; charset=UTF-8', Authorization: "Bearer access_token"}

--- a/test/embulk/input/test_sfdc.rb
+++ b/test/embulk/input/test_sfdc.rb
@@ -6,30 +6,30 @@ module Embulk
     class SfdcInputPluginTest < Test::Unit::TestCase
       def test_run
         any_instance_of(Sfdc::Api) do |klass|
-        mock(klass).setup(config) do
-          api = Sfdc::Api.new(login_url)
-          api.client.base_url = instance_url
-          api.instance_variable_set(:@version_path, version_path)
-          api.client.default_header = {Accept: 'application/json; charset=UTF-8', Authorization: "Bearer access_token"}
-          api
-        end
+          mock(klass).setup(config) do
+            api = Sfdc::Api.new(login_url)
+            api.client.base_url = instance_url
+            api.instance_variable_set(:@version_path, version_path)
+            api.client.default_header = {Accept: 'application/json; charset=UTF-8', Authorization: "Bearer access_token"}
+            api
+          end
 
-        mock(klass).search(soql) do
-          {
-            "totalSize" => 5,
-            "done" => false,
-            "nextRecordsUrl" => next_records_url,
-            "records" => records_with_attributes[0..3],
-          }
-        end
+          mock(klass).search(soql) do
+            {
+              "totalSize" => 5,
+              "done" => false,
+              "nextRecordsUrl" => next_records_url,
+              "records" => records_with_attributes[0..3],
+            }
+          end
 
-        mock(klass).get(next_records_url) do
-          {
-            "totalSize" => 5,
-            "done" => true,
-            "records" => records_with_attributes[4..5],
-          }
-        end
+          mock(klass).get(next_records_url) do
+            {
+              "totalSize" => 5,
+              "done" => true,
+              "records" => records_with_attributes[4..5],
+            }
+          end
         end
 
         page_builder = Object.new # add mock later


### PR DESCRIPTION
`Sfdc::Api#authentication` and `Sfdc::Api#set_latest_version` are methods to prepare sfdc REST API, so they should be private method. I implemented it, but their tests remain because I want to check they work well because they may cause critical bug by mistake, I think.

(edited) I modified tests for `#authentication` and `#set_latest_version` to use `#setup`.