### PR TITLE
Revert "Remove string to symbol transform"

### DIFF
--- a/lib/embulk/input/sfdc_api/api.rb
+++ b/lib/embulk/input/sfdc_api/api.rb
@@ -42,7 +42,14 @@ module Embulk
 
         private
 
-        def authentication(login_url, config)
+        def authentication(login_url, _config)
+          # NOTE: At SfdcInputPlugin#init, we use Symbol as each key
+          #       for task (Hash), but at SfdcInputPlugin#run, task
+          #       has them as String...:(
+          #       So, I translate keys from String to Symbol
+          config = {}
+          _config.each { |key, value| config[key.to_sym] = value }
+
           params = {
             grant_type: 'password',
             client_id: config[:client_id],


### PR DESCRIPTION
This reverts commit 512a0d5956631d16a58606f7c600d750e8201a66.

`authentication` method receiving from `task["config"]` in `init` method that is a plain Hash with string keys.
So transform keys are needed to access by Symbol key.