### PR TITLE
Rename: commit_report -> task_report renamed by Embulk since 0.7

### DIFF
--- a/lib/embulk/input/sfdc.rb
+++ b/lib/embulk/input/sfdc.rb
@@ -33,7 +33,7 @@ module Embulk
       end
 
       def self.resume(task, columns, count, &control)
-        commit_reports = yield(task, columns, count)
+        task_reports = yield(task, columns, count)
 
         next_config_diff = {}
         return next_config_diff
@@ -75,8 +75,8 @@ module Embulk
 
         logger.debug "Added all records."
 
-        commit_report = {}
-        return commit_report
+        task_report = {}
+        return task_report
       end
 
       private


### PR DESCRIPTION
http://www.embulk.org/docs/release/release-0.7.0.html#java-plugin-api
Officially, commit report should be task report since 0.7.0.