### PR TITLE
Scheduled execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This plugin requires your "security token", but if you forget it, please visit "
 - **columns** target SObject attributes. You can generate this configuration by `guess` command (array, required)
 - **retry_initial_wait_sec**: Wait seconds for exponential backoff initial value (integer, default: 1)
 - **retry_limit**: Try to retry this times (integer, default: 5)
+- **continue_from**: Only process records after this time. This option didn't filled or SOQL SELECT-clause doesn't contain `LastModifiedDate`, all fetched records are processed. (string, default: nil)
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This plugin uses Force.com REST API.
 Required Embulk version >= 0.6.13.
 
 * **Plugin type**: input
-* **Resume supported**: no
+* **Resume supported**: yes (not released yet)
 * **Cleanup supported**: no
 * **Guess supported**: yes
 

--- a/test/embulk/input/test_sfdc.rb
+++ b/test/embulk/input/test_sfdc.rb
@@ -22,7 +22,7 @@ module Embulk
 
         def test_without_last_fetched
           t = task.dup
-          t.delete(:last_fetched)
+          t.delete(:continue_from)
           @plugin = Sfdc.new(t, nil, nil, @page_builder)
 
           stub(@api).search { response }
@@ -35,7 +35,7 @@ module Embulk
         end
 
         def test_with_last_fetched
-          t = task.merge(last_fetched: response["records"][1]["LastModifiedDate"])
+          t = task.merge(continue_from: response["records"][1]["LastModifiedDate"])
           @plugin = Sfdc.new(t, nil, nil, @page_builder)
 
           stub(@api).search { response }
@@ -50,7 +50,7 @@ module Embulk
         end
 
         def test_without_last_modified_date_record
-          t = task.merge(last_fetched: response["records"][1]["LastModifiedDate"])
+          t = task.merge(continue_from: response["records"][1]["LastModifiedDate"])
           @plugin = Sfdc.new(t, nil, nil, @page_builder)
 
           records = response.dup
@@ -228,7 +228,7 @@ module Embulk
           schema: config["columns"],
           retry_limit: 5,
           retry_initial_wait_sec: 1,
-          last_fetched: nil,
+          continue_from: nil,
         }
         columns = task[:schema].map do |col|
           Column.new(nil, col["name"], col["type"].to_sym, col["format"])

--- a/test/embulk/input/test_sfdc.rb
+++ b/test/embulk/input/test_sfdc.rb
@@ -153,6 +153,7 @@ module Embulk
           schema: config["columns"],
           retry_limit: 5,
           retry_initial_wait_sec: 1,
+          last_fetched: nil,
         }
         columns = task[:schema].map do |col|
           Column.new(nil, col["name"], col["type"].to_sym, col["format"])
@@ -162,12 +163,11 @@ module Embulk
         Sfdc.transaction(embulk_config, &control)
       end
 
-      def test_resume
-        called = false
-        control = proc { called = true }
+      def test_resume_task_reports
+        task_reports = [1, 2, 3]
+        control = proc { task_reports }
 
-        Sfdc.resume({dummy: :task}, {dummy: :columns}, 1, &control)
-        assert_true(called)
+        assert_equal task_reports.first, Sfdc.resume({dummy: :task}, {dummy: :columns}, 1, &control)
       end
 
       class GuessTest < self


### PR DESCRIPTION
Add `continue_from` option for resume.
That supports `embulk run config.yml -o next.yml`.