### PR TITLE
retrieve child-to-parent relationship columns

### DIFF
--- a/lib/embulk/input/sfdc.rb
+++ b/lib/embulk/input/sfdc.rb
@@ -140,7 +140,7 @@ module Embulk
       end
 
       def add_records(records)
-        records = SfdcInputPluginUtils.extract_records(records)
+        records = SfdcInputPluginUtils.extract_records(records, @schema)
 
         records.each do |record|
           if record.has_key?("LastModifiedDate")

--- a/lib/embulk/input/sfdc_input_plugin_utils.rb
+++ b/lib/embulk/input/sfdc_input_plugin_utils.rb
@@ -23,10 +23,51 @@ module Embulk
 
       # NOTE: Force.com query API returns JSON including
       #       sobject name (a.k.a "attributes") and record data.
+      #       record data has 3 types
+      #         1. self columns
+      #         2. parent's columns (follow child-to-parent relationship)
+      #         3. child's columns (follow parent-to-child relationship)
       def self.extract_records(json)
         json.map do |elements|
-          elements.reject {|key, _| key == "attributes" }
+          record = {}
+
+          elements.each {|key, value|
+            if key != "attributes"
+              if value.is_a?(Hash)
+                # for parent's columns
+                if value.has_key?("attributes")
+                  record.merge!(extract_parent_elements(key, value))
+                # for child's columns or something else
+                else
+                  record[key] = value
+                end
+              # for self columns
+              else
+                record[key] = value
+              end
+            end
+          }
+          record
         end
+      end
+
+      def self.extract_parent_elements(key, elements)
+        record = {}
+
+        elements.each{|k, v|
+          full_key_name = key + '.' + k
+
+          # follow child-to-parent relationship recursivly
+          if v.is_a?(Hash)
+            if v.has_key?("attributes")
+              record.merge!(extract_parent_elements(full_key_name, v))
+            end
+          else
+            record[full_key_name] = v if k != "attributes"
+          end
+        }
+
+        record
       end
     end
   end

--- a/test/embulk/input/test_sfdc_input_plugin_utils.rb
+++ b/test/embulk/input/test_sfdc_input_plugin_utils.rb
@@ -27,7 +27,7 @@ class EmbulkInputPluginUtilsTest < Test::Unit::TestCase
     assert_equal(expected, actual)
   end
 
-  def test_extract_records
+  def test_extract_records_without_schema
     json = [
       {
         "attributes" => {
@@ -114,6 +114,177 @@ class EmbulkInputPluginUtilsTest < Test::Unit::TestCase
        "Id" => "a0028000002prfUAAQ",
        "Name" => "cat",
        "renban__c" => "201506-1078",
+       "poetry__r" => {
+         "attributes" => {
+           "type" => "poetry__c",
+           "url"  => "/services/data/v2.0/sobjects/poetry__c/b0028000002prfUAAQ"
+         },
+         "Id" => "b0028000002prfUAAQ",
+         "Name" => "dog",
+         "kajin__r" => {
+           "attributes" => {
+             "type" => "kajin__c",
+             "url"  => "/services/data/v2.0/sobjects/kajin__c/d0028000002prfUAAQ"
+           },
+           "Id" => "d0028000002prfUAAQ",
+           "Name" => "semimaru",
+         }
+       },
+       "waka__c" => {
+         "totalSize" => 1,
+         "done" => true,
+         "records" => [
+           {
+             "attributes" => {
+               "type" => "waka__c",
+               "url"  => "/services/data/v2.0/sobjects/waka__c/c0028000002prfUAAQ"
+             },
+             "Id" => "c0028000002prfUAAQ",
+             "Name" => "pony"
+           }
+         ]
+       }
+      },
+      {
+        "Id" => "a0028000002prg8AAA",
+        "Name" => "cat5",
+        "renban__c" => "201506-1079",
+        "poetry__r" => {
+          "attributes" => {
+            "type" => "poetry__c",
+            "url"  => "/services/data/v2.0/sobjects/poetry__c/b0028000002prg8AAA"
+          },
+          "Id" => "b0028000002prg8AAA",
+          "Name" => "dog5",
+          "kajin__r" => {
+           "attributes" => {
+             "type" => "kajin__c",
+             "url"  => "/services/data/v2.0/sobjects/kajin__c/d0028000002prg8AAA"
+           },
+           "Id" => "d0028000002prg8AAA",
+           "Name" => "semimaru5",
+         }
+        },
+        "waka__c" => {
+          "totalSize" => 1,
+          "done" => true,
+          "records" => [
+            {
+              "attributes" => {
+                "type" => "waka__c",
+                "url"  => "/services/data/v2.0/sobjects/waka__c/c0028000002prg8AAA"
+              },
+              "Id" => "c0028000002prg8AAA",
+              "Name" => "pony5"
+            }
+          ]
+        }
+      }
+    ]
+
+    actual = Embulk::Input::SfdcInputPluginUtils.extract_records(json)
+
+    assert_equal(expected, actual)
+  end
+
+  def test_extract_records_without_schema_no_type_json
+    json = [
+      {
+        "attributes" => {
+          "type" => "manyo__c",
+          "url" => "/services/data/v2.0/sobjects/manyo__c/a0028000002prfUAAQ"
+        },
+       "Id" => "a0028000002prfUAAQ",
+       "Name" => "cat",
+       "renban__c" => "201506-1078",
+       "poetry__r" => {
+         "attributes" => {
+           "type" => "poetry__c",
+           "url"  => "/services/data/v2.0/sobjects/poetry__c/b0028000002prfUAAQ"
+         },
+         "Id" => "b0028000002prfUAAQ",
+         "Name" => "dog",
+         "kajin__r" => {
+           "attributes" => {
+             "type" => "kajin__c",
+             "url"  => "/services/data/v2.0/sobjects/kajin__c/d0028000002prfUAAQ"
+           },
+           "Id" => "d0028000002prfUAAQ",
+           "Name" => "semimaru",
+         }
+       },
+       "waka__c" => {
+         "totalSize" => 1,
+         "done" => true,
+         "records" => [
+           {
+             "attributes" => {
+               "type" => "waka__c",
+               "url"  => "/services/data/v2.0/sobjects/waka__c/c0028000002prfUAAQ"
+             },
+             "Id" => "c0028000002prfUAAQ",
+             "Name" => "pony"
+           }
+         ]
+       }
+      },
+      {
+        "attributes" => {
+          "type" => "manyo__c",
+          "url" => "/services/data/v2.0/sobjects/manyo__c/a0028000002prg8AAA"
+        },
+        "Id" => "a0028000002prg8AAA",
+        "Name" => "cat5",
+        "renban__c" => "201506-1079",
+        "poetry__r" => {
+          "attributes" => {
+            "type" => "poetry__c",
+            "url"  => "/services/data/v2.0/sobjects/poetry__c/b0028000002prg8AAA"
+          },
+          "Id" => "b0028000002prg8AAA",
+          "Name" => "dog5",
+          "kajin__r" => {
+           "attributes" => {
+             "type" => "kajin__c",
+             "url"  => "/services/data/v2.0/sobjects/kajin__c/d0028000002prg8AAA"
+           },
+           "Id" => "d0028000002prg8AAA",
+           "Name" => "semimaru5",
+         }
+        },
+        "waka__c" => {
+          "totalSize" => 1,
+          "done" => true,
+          "records" => [
+            {
+              "attributes" => {
+                "type" => "waka__c",
+                "url"  => "/services/data/v2.0/sobjects/waka__c/c0028000002prg8AAA"
+              },
+              "Id" => "c0028000002prg8AAA",
+              "Name" => "pony5"
+            }
+          ]
+        }
+      }
+    ]
+
+    schema = [
+      {"name" => "Id", "type" => "string"},
+      {"name" => "Name", "type" => "string"},
+      {"name" => "renban__c", "type" => "string"},
+      {"name" => "poetry__r.Id", "type" => "string"},
+      {"name" => "poetry__r.Name", "type" => "string"},
+      {"name" => "poetry__r.kajin__r.Id", "type" => "string"},
+      {"name" => "poetry__r.kajin__r.Name", "type" => "string"},
+      {"name" => "waka__c", "type" => "string"}
+    ]
+
+    expected = [
+      {
+       "Id" => "a0028000002prfUAAQ",
+       "Name" => "cat",
+       "renban__c" => "201506-1078",
        "poetry__r.Id" => "b0028000002prfUAAQ",
        "poetry__r.Name" => "dog",
        "poetry__r.kajin__r.Id" => "d0028000002prfUAAQ",
@@ -158,12 +329,180 @@ class EmbulkInputPluginUtilsTest < Test::Unit::TestCase
       }
     ]
 
-    actual = Embulk::Input::SfdcInputPluginUtils.extract_records(json)
+    actual = Embulk::Input::SfdcInputPluginUtils.extract_records(json, schema)
 
     assert_equal(expected, actual)
   end
 
-  def test_extract_parent_elements
+  def test_extract_records_without_schema_type_json
+    json = [
+      {
+        "attributes" => {
+          "type" => "manyo__c",
+          "url" => "/services/data/v2.0/sobjects/manyo__c/a0028000002prfUAAQ"
+        },
+       "Id" => "a0028000002prfUAAQ",
+       "Name" => "cat",
+       "renban__c" => "201506-1078",
+       "poetry__r" => {
+         "attributes" => {
+           "type" => "poetry__c",
+           "url"  => "/services/data/v2.0/sobjects/poetry__c/b0028000002prfUAAQ"
+         },
+         "Id" => "b0028000002prfUAAQ",
+         "Name" => "dog",
+         "kajin__r" => {
+           "attributes" => {
+             "type" => "kajin__c",
+             "url"  => "/services/data/v2.0/sobjects/kajin__c/d0028000002prfUAAQ"
+           },
+           "Id" => "d0028000002prfUAAQ",
+           "Name" => "semimaru",
+         }
+       },
+       "waka__c" => {
+         "totalSize" => 1,
+         "done" => true,
+         "records" => [
+           {
+             "attributes" => {
+               "type" => "waka__c",
+               "url"  => "/services/data/v2.0/sobjects/waka__c/c0028000002prfUAAQ"
+             },
+             "Id" => "c0028000002prfUAAQ",
+             "Name" => "pony"
+           }
+         ]
+       }
+      },
+      {
+        "attributes" => {
+          "type" => "manyo__c",
+          "url" => "/services/data/v2.0/sobjects/manyo__c/a0028000002prg8AAA"
+        },
+        "Id" => "a0028000002prg8AAA",
+        "Name" => "cat5",
+        "renban__c" => "201506-1079",
+        "poetry__r" => {
+          "attributes" => {
+            "type" => "poetry__c",
+            "url"  => "/services/data/v2.0/sobjects/poetry__c/b0028000002prg8AAA"
+          },
+          "Id" => "b0028000002prg8AAA",
+          "Name" => "dog5",
+          "kajin__r" => {
+           "attributes" => {
+             "type" => "kajin__c",
+             "url"  => "/services/data/v2.0/sobjects/kajin__c/d0028000002prg8AAA"
+           },
+           "Id" => "d0028000002prg8AAA",
+           "Name" => "semimaru5",
+         }
+        },
+        "waka__c" => {
+          "totalSize" => 1,
+          "done" => true,
+          "records" => [
+            {
+              "attributes" => {
+                "type" => "waka__c",
+                "url"  => "/services/data/v2.0/sobjects/waka__c/c0028000002prg8AAA"
+              },
+              "Id" => "c0028000002prg8AAA",
+              "Name" => "pony5"
+            }
+          ]
+        }
+      }
+    ]
+
+    schema = [
+      {"name" => "Id", "type" => "string"},
+      {"name" => "Name", "type" => "string"},
+      {"name" => "renban__c", "type" => "string"},
+      {"name" => "poetry__r", "type" => "json"},
+      {"name" => "waka__c", "type" => "string"}
+    ]
+
+    expected = [
+      {
+       "Id" => "a0028000002prfUAAQ",
+       "Name" => "cat",
+       "renban__c" => "201506-1078",
+       "poetry__r" => {
+         "attributes" => {
+           "type" => "poetry__c",
+           "url"  => "/services/data/v2.0/sobjects/poetry__c/b0028000002prfUAAQ"
+         },
+         "Id" => "b0028000002prfUAAQ",
+         "Name" => "dog",
+         "kajin__r" => {
+           "attributes" => {
+             "type" => "kajin__c",
+             "url"  => "/services/data/v2.0/sobjects/kajin__c/d0028000002prfUAAQ"
+           },
+           "Id" => "d0028000002prfUAAQ",
+           "Name" => "semimaru",
+         }
+       },
+       "waka__c" => {
+         "totalSize" => 1,
+         "done" => true,
+         "records" => [
+           {
+             "attributes" => {
+               "type" => "waka__c",
+               "url"  => "/services/data/v2.0/sobjects/waka__c/c0028000002prfUAAQ"
+             },
+             "Id" => "c0028000002prfUAAQ",
+             "Name" => "pony"
+           }
+         ]
+       }
+      },
+      {
+        "Id" => "a0028000002prg8AAA",
+        "Name" => "cat5",
+        "renban__c" => "201506-1079",
+        "poetry__r" => {
+          "attributes" => {
+            "type" => "poetry__c",
+            "url"  => "/services/data/v2.0/sobjects/poetry__c/b0028000002prg8AAA"
+          },
+          "Id" => "b0028000002prg8AAA",
+          "Name" => "dog5",
+          "kajin__r" => {
+           "attributes" => {
+             "type" => "kajin__c",
+             "url"  => "/services/data/v2.0/sobjects/kajin__c/d0028000002prg8AAA"
+           },
+           "Id" => "d0028000002prg8AAA",
+           "Name" => "semimaru5",
+         }
+        },
+        "waka__c" => {
+          "totalSize" => 1,
+          "done" => true,
+          "records" => [
+            {
+              "attributes" => {
+                "type" => "waka__c",
+                "url"  => "/services/data/v2.0/sobjects/waka__c/c0028000002prg8AAA"
+              },
+              "Id" => "c0028000002prg8AAA",
+              "Name" => "pony5"
+            }
+          ]
+        }
+      }
+    ]
+
+    actual = Embulk::Input::SfdcInputPluginUtils.extract_records(json, schema)
+
+    assert_equal(expected, actual)
+  end
+
+  def test_extract_parent_elements_no_type_json
     key = "poetry__r"
 
     elements = {
@@ -183,6 +522,8 @@ class EmbulkInputPluginUtilsTest < Test::Unit::TestCase
       }
     }
 
+    type_json_columns = {}
+
     expected = {
       "poetry__r.Id" => "b0028000002prg8AAA",
       "poetry__r.Name" => "dog5",
@@ -190,7 +531,67 @@ class EmbulkInputPluginUtilsTest < Test::Unit::TestCase
       "poetry__r.kajin__r.Name" => "semimaru5"
     }
 
-    actual = Embulk::Input::SfdcInputPluginUtils.extract_parent_elements(key, elements)
+    actual = Embulk::Input::SfdcInputPluginUtils.extract_parent_elements(key, elements, type_json_columns)
+
+    assert_equal(expected, actual)
+  end
+
+  def test_extract_parent_elements_type_json
+    key = "poetry__r"
+
+    elements = {
+      "attributes" => {
+        "type" => "poetry__c",
+        "url"  => "/services/data/v2.0/sobjects/poetry__c/b0028000002prg8AAA"
+      },
+      "Id" => "b0028000002prg8AAA",
+      "Name" => "dog5",
+      "kajin__r" => {
+        "attributes" => {
+          "type" => "kajin__c",
+          "url"  => "/services/data/v2.0/sobjects/kajin__c/d0028000002prg8AAA"
+        },
+        "Id" => "d0028000002prg8AAA",
+        "Name" => "semimaru5"
+      }
+    }
+
+    type_json_columns = {
+      "poetry__r.kajin__r" => 1
+    }
+
+    expected = {
+      "poetry__r.Id" => "b0028000002prg8AAA",
+      "poetry__r.Name" => "dog5",
+      "poetry__r.kajin__r" => {
+        "attributes" => {
+          "type" => "kajin__c",
+          "url"  => "/services/data/v2.0/sobjects/kajin__c/d0028000002prg8AAA"
+        },
+        "Id" => "d0028000002prg8AAA",
+        "Name" => "semimaru5"
+      }
+    }
+
+    actual = Embulk::Input::SfdcInputPluginUtils.extract_parent_elements(key, elements, type_json_columns)
+
+    assert_equal(expected, actual)
+  end
+
+  def test_schema_to_type_json_columns
+    schema = [
+      {"name" => "Id", "type" => "string"},
+      {"name" => "Name", "type" => "string"},
+      {"name" => "renban__c", "type" => "string"},
+      {"name" => "poetry__r", "type" => "json"},
+      {"name" => "waka__c", "type" => "string"}
+    ]
+
+    expected = {
+      "poetry__r" => 1
+    }
+
+    actual = Embulk::Input::SfdcInputPluginUtils.schema_to_type_json_columns(schema)
 
     assert_equal(expected, actual)
   end

--- a/test/embulk/input/test_sfdc_input_plugin_utils.rb
+++ b/test/embulk/input/test_sfdc_input_plugin_utils.rb
@@ -36,7 +36,37 @@ class EmbulkInputPluginUtilsTest < Test::Unit::TestCase
         },
        "Id" => "a0028000002prfUAAQ",
        "Name" => "cat",
-       "renban__c" => "201506-1078"
+       "renban__c" => "201506-1078",
+       "poetry__r" => {
+         "attributes" => {
+           "type" => "poetry__c",
+           "url"  => "/services/data/v2.0/sobjects/poetry__c/b0028000002prfUAAQ"
+         },
+         "Id" => "b0028000002prfUAAQ",
+         "Name" => "dog",
+         "kajin__r" => {
+           "attributes" => {
+             "type" => "kajin__c",
+             "url"  => "/services/data/v2.0/sobjects/kajin__c/d0028000002prfUAAQ"
+           },
+           "Id" => "d0028000002prfUAAQ",
+           "Name" => "semimaru",
+         }
+       },
+       "waka__c" => {
+         "totalSize" => 1,
+         "done" => true,
+         "records" => [
+           {
+             "attributes" => {
+               "type" => "waka__c",
+               "url"  => "/services/data/v2.0/sobjects/waka__c/c0028000002prfUAAQ"
+             },
+             "Id" => "c0028000002prfUAAQ",
+             "Name" => "pony"
+           }
+         ]
+       }
       },
       {
         "attributes" => {
@@ -45,24 +75,122 @@ class EmbulkInputPluginUtilsTest < Test::Unit::TestCase
         },
         "Id" => "a0028000002prg8AAA",
         "Name" => "cat5",
-        "renban__c" => "201506-1079"
-      },
+        "renban__c" => "201506-1079",
+        "poetry__r" => {
+          "attributes" => {
+            "type" => "poetry__c",
+            "url"  => "/services/data/v2.0/sobjects/poetry__c/b0028000002prg8AAA"
+          },
+          "Id" => "b0028000002prg8AAA",
+          "Name" => "dog5",
+          "kajin__r" => {
+           "attributes" => {
+             "type" => "kajin__c",
+             "url"  => "/services/data/v2.0/sobjects/kajin__c/d0028000002prg8AAA"
+           },
+           "Id" => "d0028000002prg8AAA",
+           "Name" => "semimaru5",
+         }
+        },
+        "waka__c" => {
+          "totalSize" => 1,
+          "done" => true,
+          "records" => [
+            {
+              "attributes" => {
+                "type" => "waka__c",
+                "url"  => "/services/data/v2.0/sobjects/waka__c/c0028000002prg8AAA"
+              },
+              "Id" => "c0028000002prg8AAA",
+              "Name" => "pony5"
+            }
+          ]
+        }
+      }
     ]
 
     expected = [
       {
        "Id" => "a0028000002prfUAAQ",
        "Name" => "cat",
-       "renban__c" => "201506-1078"
+       "renban__c" => "201506-1078",
+       "poetry__r.Id" => "b0028000002prfUAAQ",
+       "poetry__r.Name" => "dog",
+       "poetry__r.kajin__r.Id" => "d0028000002prfUAAQ",
+       "poetry__r.kajin__r.Name" => "semimaru",
+       "waka__c" => {
+         "totalSize" => 1,
+         "done" => true,
+         "records" => [
+           {
+             "attributes" => {
+               "type" => "waka__c",
+               "url"  => "/services/data/v2.0/sobjects/waka__c/c0028000002prfUAAQ"
+             },
+             "Id" => "c0028000002prfUAAQ",
+             "Name" => "pony"
+           }
+         ]
+       }
       },
       {
         "Id" => "a0028000002prg8AAA",
         "Name" => "cat5",
-        "renban__c" => "201506-1079"
-      },
+        "renban__c" => "201506-1079",
+        "poetry__r.Id" => "b0028000002prg8AAA",
+        "poetry__r.Name" => "dog5",
+        "poetry__r.kajin__r.Id" => "d0028000002prg8AAA",
+        "poetry__r.kajin__r.Name" => "semimaru5",
+        "waka__c" => {
+          "totalSize" => 1,
+          "done" => true,
+          "records" => [
+            {
+              "attributes" => {
+                "type" => "waka__c",
+                "url"  => "/services/data/v2.0/sobjects/waka__c/c0028000002prg8AAA"
+              },
+              "Id" => "c0028000002prg8AAA",
+              "Name" => "pony5"
+            }
+          ]
+        }
+      }
     ]
 
     actual = Embulk::Input::SfdcInputPluginUtils.extract_records(json)
+
+    assert_equal(expected, actual)
+  end
+
+  def test_extract_parent_elements
+    key = "poetry__r"
+
+    elements = {
+      "attributes" => {
+        "type" => "poetry__c",
+        "url"  => "/services/data/v2.0/sobjects/poetry__c/b0028000002prg8AAA"
+      },
+      "Id" => "b0028000002prg8AAA",
+      "Name" => "dog5",
+      "kajin__r" => {
+        "attributes" => {
+          "type" => "kajin__c",
+          "url"  => "/services/data/v2.0/sobjects/kajin__c/d0028000002prg8AAA"
+        },
+        "Id" => "d0028000002prg8AAA",
+        "Name" => "semimaru5"
+      }
+    }
+
+    expected = {
+      "poetry__r.Id" => "b0028000002prg8AAA",
+      "poetry__r.Name" => "dog5",
+      "poetry__r.kajin__r.Id" => "d0028000002prg8AAA",
+      "poetry__r.kajin__r.Name" => "semimaru5"
+    }
+
+    actual = Embulk::Input::SfdcInputPluginUtils.extract_parent_elements(key, elements)
 
     assert_equal(expected, actual)
   end


### PR DESCRIPTION
I want to retrieve child-to-parent relationship columns.

cf) Relationship Queries
https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_relationships.htm

For example, Contact object is a child of Account object. When I need Contact object's Id, Name, its parent Id and its parent Name, I write following embulk settings. 

```.yaml
in:
  # AUTHENTICATION_INFO
  target: Contact
  soql: SELECT Id, Name, Account.Id, Account.Name from Contact
  columns:
    - {name: Id, type: string}
    - {name: Name, type: string}
    - {name: Account.Id, type: string}
    - {name: Account.Name, type: string}
# FILTER_AND_OUTPUT
```

`embulk run` and Salesforce.com API returns JSON like this

```
{
  "totalSize": 1,
  "done": true,
  "records": [
    {
      "attributes": {"type": "Contact", "url": "/services/data/vxx.0/sobjects/Contact/0032800000xxxxx"},
      "Id": "0032800000xxxxx",
      "Name": "Contact Name",
      "Account": {
        "attributes": {"type": Account", "url": "/services/data/vxx.0/sobjects/Account/0012800000xxxxx"},
        "Id": "0012800000xxxxx",
        "Name": "Account Name"
      }
    }
  ]
}
```

v0.2.1 process it

```
************************* 1 *************************
          Id (string) : 0032800000xxxxx
         Name(string) : Contact Name
  Account.Id (string) : 
Account.Name (string) : 
```

But I want to get

```
************************* 1 *************************
          Id (string) : 0032800000xxxxx
         Name(string) : Contact Name
  Account.Id (string) : 0012800000xxxxx
Account.Name (string) : Account Name
```

So I write code for retrieving child-to-parent relationship columns.

I'm not familiar with Ruby. Maybe I write some code doesn't match Ruby way.
I will be grateful for any advice in that case.