### PR TITLE
SFDC always returns 400 when connected with TLSv1

### DIFF
--- a/lib/embulk/input/sfdc_api/api.rb
+++ b/lib/embulk/input/sfdc_api/api.rb
@@ -20,7 +20,9 @@ module Embulk
         def initialize
           @version_path = ""
           @client = HTTPClient.new
+          # @client.debug_dev = STDERR
           @client.default_header = {Accept: 'application/json; charset=UTF-8'}
+          @client.ssl_config.ssl_version = "TLSv1.2"
         end
 
         def get(path, parameters={})


### PR DESCRIPTION
On Java 7 and HTTPClient, it will use TLSv1 to access SFDC API.
But it fails: {"error":"unknown_error","error_description":"retry your request"}
Java 8 will use TLSv1.2 so it works.
This commit force to use TLSv1.2 to avoid such error.

See also SFDC official announce:
https://help.salesforce.com/apex/HTViewSolution?id=000221207#Whendisable